### PR TITLE
Add insertBefore method & Fix path index outdated

### DIFF
--- a/src/DefaultNode.php
+++ b/src/DefaultNode.php
@@ -185,11 +185,23 @@ class DefaultNode implements Node
     protected function insertAfter(ReplacementMapStep $mapStep, Node $newChild)
     {
         $newChildArray = [];
-        foreach($this->children as $index => $child) {
+        foreach($this->children as $child) {
             $newChildArray[] = $child;
             if($child === $mapStep->getOldNode()) {
                 $newChildArray[] = $newChild;
             }
+        }
+        $this->children = $newChildArray;
+    }
+
+    protected function insertBefore(ReplacementMapStep $mapStep, Node $newChild)
+    {
+        $newChildArray = [];
+        foreach($this->children as $child) {
+            if($child === $mapStep->getOldNode()) {
+                $newChildArray[] = $newChild;
+            }
+            $newChildArray[] = $child;
         }
         $this->children = $newChildArray;
     }


### PR DESCRIPTION
When a method inserts children, the indexes of the other children changes. This commit ensures, that the paths indexes are updated, when the indexes of the children are upated.
